### PR TITLE
Supression de l'api de mineweb.

### DIFF
--- a/Layouts/default.ctp
+++ b/Layouts/default.ctp
@@ -34,8 +34,10 @@
   <body>
       <?= $this->element('css'); ?>
       <?php
-        $json = file_get_contents('http://api.mineweb.org/api/v2/theme/all');
-        $mw = json_decode($json, true);
+        #Suppression de l'api mineweb car elle a été supprimé..
+        #Ancien code avec l'api mineweb :
+        #$json = file_get_contents('http://api.mineweb.org/api/v2/theme/all');
+        #$mw = json_decode($json, true);
         ?>
         <div id="loader"></div>
       <?= $this->element('top'); ?>


### PR DESCRIPTION
Lorsque le theme cherche à acceder à l'api de minweb cela cause un gros ralentissement sur tout le site car l'api a été supprimée. J'ai donc enlever la vérification la reqête vers l'api. Pour le moment aucun alternatives c'est juste un patch pour éviter le ralentissement. J'ai quand même laissé l'ancienne vérification en commentaire au cas ou certains voudraient réutiliser le code pour leur api.